### PR TITLE
Hyperlink to the GitHub Pages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-KeeChallenge v1.4
+[KeeChallenge v1.4](http://brush701.github.io/keechallenge/ "KeeChallenge Documentation")
 =================
 Copyright 2014 Ben Rush
 


### PR DESCRIPTION
README now links to http://brush701.github.io/keechallenge/