### PR TITLE
Added abort button.

### DIFF
--- a/KeeChallenge/src/KeyEntry.Designer.cs
+++ b/KeeChallenge/src/KeyEntry.Designer.cs
@@ -30,6 +30,7 @@
         {
             this.promptLabel = new System.Windows.Forms.Label();
             this.progressBar = new System.Windows.Forms.ProgressBar();
+            this.abortButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // promptLabel
@@ -45,8 +46,18 @@
             // 
             this.progressBar.Location = new System.Drawing.Point(12, 25);
             this.progressBar.Name = "progressBar";
-            this.progressBar.Size = new System.Drawing.Size(260, 23);
+            this.progressBar.Size = new System.Drawing.Size(200, 23);
             this.progressBar.TabIndex = 1;
+            // 
+            // abortButton
+            // 
+            this.abortButton.Location = new System.Drawing.Point(218, 25);
+            this.abortButton.Name = "abortButton";
+            this.abortButton.Size = new System.Drawing.Size(54, 23);
+            this.abortButton.TabIndex = 2;
+            this.abortButton.Text = "Abort";
+            this.abortButton.UseVisualStyleBackColor = true;
+            this.abortButton.Click += new System.EventHandler(this.AbortButton_Click);
             // 
             // KeyEntry
             // 
@@ -54,6 +65,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(284, 58);
             this.ControlBox = false;
+            this.Controls.Add(this.abortButton);
             this.Controls.Add(this.progressBar);
             this.Controls.Add(this.promptLabel);
             this.MaximizeBox = false;
@@ -71,5 +83,6 @@
 
         private System.Windows.Forms.Label promptLabel;
         private System.Windows.Forms.ProgressBar progressBar;
+        private System.Windows.Forms.Button abortButton;
     }
 }

--- a/KeeChallenge/src/KeyEntry.cs
+++ b/KeeChallenge/src/KeyEntry.cs
@@ -28,7 +28,7 @@ namespace KeeChallenge
 {
     public partial class KeyEntry : Form
     {
-        private System.Windows.Forms.Timer countdown;
+        private Timer countdown;
         private byte[] m_challenge;
         private byte[] m_response;
         private YubiWrapper yubi;
@@ -92,23 +92,28 @@ namespace KeeChallenge
             return;
         }
 
-        private void keyWorkerDone(object sender, EventArgs e) //guaranteed to run after YubiChallengeResponse
+        private void KeyWorkerDone(object sender, EventArgs e) //guaranteed to run after YubiChallengeResponse
         {
             if (success)
-                DialogResult = System.Windows.Forms.DialogResult.OK;  //setting this calls Close() IF the form is shown using ShowDialog()
-            else DialogResult = System.Windows.Forms.DialogResult.No; 
+                DialogResult = DialogResult.OK;  //setting this calls Close() IF the form is shown using ShowDialog()
+            else DialogResult = DialogResult.No; 
         }
 
-        private void Countdown(object sender, EventArgs e)
+        private void Countdown(object sender, EventArgs eventArgs)
         {
             if (countdown == null) return;
             if (progressBar.Value > 0)
                 progressBar.Value--;
             else
             {
-                countdown.Stop();
-                this.Close();
+                CountdownCompleted();
             }
+        }
+
+        private void CountdownCompleted()
+        {
+            countdown.Stop();
+            Close();
         }
         
         private void OnFormLoad(object sender, EventArgs e)
@@ -126,10 +131,10 @@ namespace KeeChallenge
                 {
                     YubiPrompt prompt = new YubiPrompt();
                     DialogResult res =  prompt.ShowDialog();
-                    if (res != System.Windows.Forms.DialogResult.Retry)
+                    if (res != DialogResult.Retry)
                     {
                         RecoveryMode = prompt.RecoveryMode;
-                        DialogResult = System.Windows.Forms.DialogResult.Abort;
+                        DialogResult = DialogResult.Abort;
                         return;
                     }
                 }
@@ -141,14 +146,14 @@ namespace KeeChallenge
                 return;
             }
             //spawn background countdown timer
-            countdown = new System.Windows.Forms.Timer();
+            countdown = new Timer();
             countdown.Tick += Countdown;
             countdown.Interval = 1000;
             countdown.Enabled = true;
 
             keyWorker = new BackgroundWorker();            
             keyWorker.DoWork += YubiChallengeResponse;
-            keyWorker.RunWorkerCompleted += keyWorkerDone;
+            keyWorker.RunWorkerCompleted += KeyWorkerDone;
             keyWorker.RunWorkerAsync();     
         }
 
@@ -164,6 +169,11 @@ namespace KeeChallenge
                 yubi.Close();
             }
             GlobalWindowManager.RemoveWindow(this);
+        }
+
+        private void AbortButton_Click(object sender, EventArgs e)
+        {
+            CountdownCompleted();
         }
     }
 }


### PR DESCRIPTION
When I enter my password into Keepass I use the secure desktop feature. With this feature turned on and while the key entry is in progress, I have to wait 15 seconds until I have control over my desktop again. 

The changes in this pull request add an abort button to the entry window to allow cancellations to happen on demand.  

These changes are for my fork: https://github.com/Silvenga/KeeChallenge-Fork